### PR TITLE
feat: Add unit value input for first batch of SKU

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -177,6 +177,7 @@ model InventoryTransaction {
   attachments              Json?
   unitsPerCarton           Int?            @map("units_per_carton")
   supplier                 String?         @map("supplier")
+  unitValue                Decimal?        @map("unit_value") @db.Decimal(12, 4)
   createdBy                User            @relation("TransactionCreator", fields: [createdById], references: [id])
   sku                      Sku             @relation(fields: [skuId], references: [id])
   warehouse                Warehouse       @relation(fields: [warehouseId], references: [id])

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -418,6 +418,7 @@ export async function POST(request: NextRequest) {
               pickupDate: pickupDate ? new Date(pickupDate) : new Date(txDate), // Use provided pickup date or default to transaction date
               createdById: session.user.id,
               unitsPerCarton: item.unitsPerCarton || sku.unitsPerCarton, // Capture units per carton - prefer provided value, fallback to SKU master
+              unitValue: item.unitValue && item.unitValue > 0 ? item.unitValue : null, // Store unit value for first batch
             }
           })
 

--- a/src/app/operations/receive/page.tsx
+++ b/src/app/operations/receive/page.tsx
@@ -62,7 +62,9 @@ export default function WarehouseReceivePage() {
       storageCartonsPerPallet: 0,
       shippingCartonsPerPallet: 0,
       configLoaded: false,
-      loadingBatch: false
+      loadingBatch: false,
+      isFirstBatch: false,
+      unitValue: 0
     }
   ])
 
@@ -137,8 +139,17 @@ export default function WarehouseReceivePage() {
       const response = await fetch(`/api/skus/${encodeURIComponent(skuCode)}/next-batch`)
       if (response.ok) {
         const data = await response.json()
+        
+        // Check if this is the first batch for this SKU
+        const checkResponse = await fetch(`/api/inventory/ledger-based?skuCode=${encodeURIComponent(skuCode)}&warehouseId=${selectedWarehouseId}`)
+        let isFirstBatch = false
+        if (checkResponse.ok) {
+          const ledgerData = await checkResponse.json()
+          isFirstBatch = !ledgerData.data || ledgerData.data.length === 0
+        }
+        
         setItems(prevItems => prevItems.map(item => 
-          item.id === itemId ? { ...item, batchLot: data.suggestedBatchLot, loadingBatch: false } : item
+          item.id === itemId ? { ...item, batchLot: data.suggestedBatchLot, loadingBatch: false, isFirstBatch } : item
         ))
       }
     } catch (error) {
@@ -162,7 +173,9 @@ export default function WarehouseReceivePage() {
         storageCartonsPerPallet: 0,
         shippingCartonsPerPallet: 0,
         configLoaded: false,
-        loadingBatch: false
+        loadingBatch: false,
+        isFirstBatch: false,
+        unitValue: 0
       }
     ])
   }
@@ -433,6 +446,11 @@ export default function WarehouseReceivePage() {
       }
       if (item.units && (!Number.isInteger(item.units) || item.units < 0)) {
         toast.error(`Invalid units value for SKU ${item.skuCode}. Must be non-negative`)
+        return
+      }
+      // Validate unit value for first batch
+      if (item.isFirstBatch && (!item.unitValue || item.unitValue <= 0)) {
+        toast.error(`Please enter a unit value for SKU ${item.skuCode} as this is the first batch`)
         return
       }
     }
@@ -766,6 +784,15 @@ export default function WarehouseReceivePage() {
                     <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
                       Units
                     </th>
+                    <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      <div className="flex items-center justify-end gap-1">
+                        Unit Value
+                        <Tooltip 
+                          content="Value per unit (only for first batch)" 
+                          iconSize="sm"
+                        />
+                      </div>
+                    </th>
                     <th className="px-4 py-3"></th>
                   </tr>
                 </thead>
@@ -917,6 +944,27 @@ export default function WarehouseReceivePage() {
                           title="Units are calculated based on cartons × units per carton"
                         />
                       </td>
+                      <td className="px-4 py-3 w-32">
+                        {item.isFirstBatch ? (
+                          <input
+                            type="number"
+                            value={item.unitValue === 0 ? '' : item.unitValue}
+                            onChange={(e) => {
+                              const value = e.target.value
+                              const newValue = value === '' ? 0 : parseFloat(value) || 0
+                              updateItem(item.id, 'unitValue', newValue)
+                            }}
+                            className="w-full px-2 py-1 border rounded text-right focus:outline-none focus:ring-1 focus:ring-primary"
+                            min="0"
+                            step="0.0001"
+                            placeholder="0.00"
+                            title="Enter the value per unit for this first batch"
+                            required={item.isFirstBatch}
+                          />
+                        ) : (
+                          <span className="text-sm text-gray-500 italic">N/A</span>
+                        )}
+                      </td>
                       <td className="px-4 py-3 w-12">
                         <button
                           type="button"
@@ -948,6 +996,7 @@ export default function WarehouseReceivePage() {
                     <td className="px-4 py-3 text-right font-semibold">
                       {items.reduce((sum, item) => sum + item.units, 0).toLocaleString()}
                     </td>
+                    <td className="px-4 py-3"></td>
                     <td className="px-4 py-3"></td>
                   </tr>
                 </tfoot>


### PR DESCRIPTION
## Summary
- Add unitValue field to InventoryTransaction model for storing initial batch values
- Update receive goods page to show value input field when receiving first batch
- Implement first batch detection via ledger API query

## Why this change?
When receiving goods for the first batch of any SKU (i.e., no batch exists in GL before that), the system needs to capture the initial unit value for cost calculations. This feature allows users to input the value when receiving the first batch.

## Test plan
- [x] Added unitValue field to Prisma schema
- [x] Updated receive page UI to conditionally show value input
- [x] Modified transaction API to handle unitValue field
- [x] Tested locally - field appears for first batch
- [x] Unit tests passing
- [x] Build successful

🤖 Generated with [Claude Code](https://claude.ai/code)