### PR TITLE
fix: Make batch lot field editable

### DIFF
--- a/src/app/operations/receive/page.tsx
+++ b/src/app/operations/receive/page.tsx
@@ -793,11 +793,11 @@ export default function WarehouseReceivePage() {
                           <input
                             type="text"
                             value={item.batchLot}
-                            className="w-full px-2 py-1 border rounded bg-gray-100"
-                            placeholder={item.loadingBatch ? "Loading..." : "Select SKU first"}
+                            onChange={(e) => updateItem(item.id, 'batchLot', e.target.value)}
+                            className="w-full px-2 py-1 border rounded focus:outline-none focus:ring-1 focus:ring-primary"
+                            placeholder={item.loadingBatch ? "Loading..." : "Enter batch/lot"}
                             required
-                            readOnly
-                            title="Batch number is automatically assigned"
+                            title="Enter or modify the batch/lot number"
                           />
                           {item.loadingBatch && (
                             <div className="absolute right-2 top-1/2 -translate-y-1/2">

--- a/src/lib/auth-test.ts
+++ b/src/lib/auth-test.ts
@@ -5,7 +5,7 @@ import { authOptions as productionAuthOptions } from './auth'
 // Test user that will be used for all authenticated requests in test mode
 // Using demo-admin to match E2E test expectations
 const TEST_USER = {
-  id: 'demo-admin-id',
+  id: '4f64cbef-3e84-470e-a8d6-be3b5e7a1fe9', // Actual demo-admin ID from database
   email: 'demo-admin@warehouse.com',
   name: 'Demo Admin',
   role: 'admin' as UserRole,


### PR DESCRIPTION
## Summary
- Made batch lot input field editable (removed readonly)
- Fixed auth-test.ts to use actual demo-admin user ID from database
- Users can now manually edit batch numbers while still getting auto-suggestions

## Changes
- Remove readonly attribute from batch lot input
- Add onChange handler to allow manual editing
- Update auth-test.ts with correct user ID to fix foreign key constraint error

## Testing
- Tested locally - batch lot field is now editable
- Auto-suggest still works when selecting SKU
- Transaction creation works without foreign key errors