### PR TITLE
fix: Resolve broken navigation links causing 404 errors

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,14 @@
+import { redirect } from 'next/navigation'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+
+export default async function AdminPage() {
+  const session = await getServerSession(authOptions)
+  
+  if (!session || session.user.role !== 'admin') {
+    redirect('/unauthorized')
+  }
+  
+  // Redirect to admin dashboard by default
+  redirect('/admin/dashboard')
+}

--- a/src/components/dashboard/market-section.tsx
+++ b/src/components/dashboard/market-section.tsx
@@ -169,7 +169,7 @@ export function MarketSection({ data, loading }: MarketSectionProps) {
 
         {/* Quick Actions - Streamlined to single most relevant action */}
         <div className="md:col-span-2 lg:col-span-3 mt-2">
-          <Link href="/market/shipment-planning/new" className="flex items-center justify-center gap-2 p-4 border rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+          <Link href="/market/shipment-planning" className="flex items-center justify-center gap-2 p-4 border rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
             <Calendar className="h-5 w-5 text-primary" />
             <span className="font-medium">Plan New Shipment</span>
           </Link>


### PR DESCRIPTION
## Summary
- Fixed broken link to shipment planning that was pointing to /new route
- Added admin index page that redirects to admin dashboard
- Prevents RSC 404 errors in browser console

## Changes
- Updated market section link from `/market/shipment-planning/new` to `/market/shipment-planning`
- Created `/admin/page.tsx` that redirects to `/admin/dashboard`

## Testing
- Verified no more 404 errors in browser console
- All navigation links work correctly