### PR TITLE
chore: Bump version to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2025-07-29
+
+### Added
+- S3 bucket configuration for production file storage
+- GitHub deployments integration for deployment tracking
+
+### Fixed
+- Removed non-existent admin dashboard page
+- Updated package-lock.json to resolve dependency issues
+
+### Changed
+- Updated version display in UI components
+
 ## [0.2.0] - 2025-07-29
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "warehouse-management-system",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "scripts": {
     "dev": "node scripts/dev/dev-webpack.js",

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -174,7 +174,7 @@ export default function AdminSettingsPage() {
         <div className="border rounded-lg p-6">
           <h3 className="text-lg font-semibold mb-4">System Information</h3>
           <div className="grid gap-4 md:grid-cols-2">
-            <InfoItem label="Version" value="0.2.0" />
+            <InfoItem label="Version" value="0.2.1" />
             <InfoItem label="Database" value="PostgreSQL 15.4" />
             <InfoItem label="Environment" value="Development" />
             <InfoItem label="Last Backup" value="Never" />

--- a/src/components/layout/main-nav.tsx
+++ b/src/components/layout/main-nav.tsx
@@ -138,7 +138,7 @@ export function MainNav() {
               </Link>
               {/* Version */}
               <span className={cn("text-xs text-gray-500 transition-all duration-300", isTabletCollapsed && "md:hidden lg:inline")}>
-                v0.2.0
+                v0.2.1
               </span>
             </div>
             


### PR DESCRIPTION
## Summary

Bump version to 0.2.1 for the upcoming release.

## Changes
- Updated version in package.json
- Updated version display in UI components
- Added changelog entry for 0.2.1

## Changelog for 0.2.1
- Added S3 bucket configuration for production file storage
- Added GitHub deployments integration
- Fixed admin dashboard page removal
- Fixed package-lock.json dependency issues

🤖 Generated with [Claude Code](https://claude.ai/code)