### PR TITLE
fix: Capture build time at build phase

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -94,7 +94,7 @@ const nextConfig = {
   // Environment variables validation
   env: {
     NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000',
-    NEXT_PUBLIC_BUILD_TIME: new Date().toISOString(),
+    NEXT_PUBLIC_BUILD_TIME: process.env.BUILD_TIME || new Date().toISOString(),
     NEXT_PUBLIC_VERSION: version,
   },
   

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev:turbo": "node scripts/dev/dev-with-port.js --turbo",
     "dev:port": "node scripts/dev/dev-with-port.js",
     "dev:logged": "node server.js",
-    "build": "next build",
+    "build": "BUILD_TIME=$(date -u +\"%Y-%m-%dT%H:%M:%SZ\") next build",
     "build:prod": "NODE_ENV=production npm run clean && npm run build && npm run post-build",
     "build:analyze": "ANALYZE=true next build",
     "clean": "rm -rf .next out dist",


### PR DESCRIPTION
## Summary
- Fixed version tooltip to show actual deployment time instead of current time
- Modified build script to capture BUILD_TIME environment variable during build phase
- Updated next.config.js to use BUILD_TIME from environment

## Changes
- Updated package.json build script to set BUILD_TIME
- Modified next.config.js to read BUILD_TIME from environment

This ensures the version tooltip shows when the app was actually deployed, not the current time when hovering.