### PR TITLE
fix: Set BUILD_TIME in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,7 +103,7 @@ jobs:
           npx prisma migrate deploy || echo "No pending migrations"
           
           echo "🔨 Building application..."
-          npm run build
+          BUILD_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ") npm run build
           
           echo "♻️ Restarting application..."
           pm2 restart wms-app || pm2 start ecosystem.config.js

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev:turbo": "node scripts/dev/dev-with-port.js --turbo",
     "dev:port": "node scripts/dev/dev-with-port.js",
     "dev:logged": "node server.js",
-    "build": "BUILD_TIME=$(date -u +\"%Y-%m-%dT%H:%M:%SZ\") next build",
+    "build": "next build",
     "build:prod": "NODE_ENV=production npm run clean && npm run build && npm run post-build",
     "build:analyze": "ANALYZE=true next build",
     "clean": "rm -rf .next out dist",


### PR DESCRIPTION
## Summary
- Moved BUILD_TIME environment variable setting to deployment workflow
- This ensures it works properly in the CI/CD environment

## Changes
- Updated deploy.yml to set BUILD_TIME during build
- Reverted package.json to original build command

The Unix-style command substitution in package.json doesn't work reliably across all environments. Setting it directly in the deployment workflow ensures consistent behavior.