### PR TITLE
fix: Export BUILD_TIME in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,7 +103,9 @@ jobs:
           npx prisma migrate deploy || echo "No pending migrations"
           
           echo "🔨 Building application..."
-          BUILD_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ") npm run build
+          export BUILD_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          echo "Build time: $BUILD_TIME"
+          npm run build
           
           echo "♻️ Restarting application..."
           pm2 restart wms-app || pm2 start ecosystem.config.js


### PR DESCRIPTION
## Summary
- Export BUILD_TIME environment variable to ensure it's available to npm run build
- Add logging to verify the build time is being set correctly

## Issue
The version tooltip was still showing current time because the BUILD_TIME variable wasn't being passed to the build process in the SSH session.

## Solution
Using `export` ensures the variable is available to child processes in the deployment script.