### PR TITLE
fix: Remove 1-year historical date restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "warehouse-management-system",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "dev": "node scripts/dev/dev-webpack.js",

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -152,14 +152,7 @@ export async function POST(request: NextRequest) {
       }, { status: 400 })
     }
 
-    // Validate date is not too far in the past (e.g., 1 year)
-    const oneYearAgo = new Date()
-    oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1)
-    if (transactionDateObj < oneYearAgo) {
-      return NextResponse.json({ 
-        error: 'Transaction date is too far in the past (max 1 year)' 
-      }, { status: 400 })
-    }
+    // Historical date validation removed - businesses may need to enter old data for migration or corrections
 
     // Validate warehouse assignment for staff
     if (session.user.role === 'staff' && !session.user.warehouseId) {


### PR DESCRIPTION
## Summary
Removes the 1-year historical date validation that was preventing legitimate business operations.

## Changes
- Removed validation that blocked transactions older than 1 year
- Updated version to 0.3.0 (minor release due to behavior change)

## Rationale
Businesses need to enter historical data for:
- Initial system setup with past records
- Data migration from legacy systems
- Audit corrections and adjustments
- Year-end reconciliations

## Other Restrictions Found
During investigation, found several other restrictions that may need review:
- Backdating prevention (blocks any transaction before the last one)
- 99,999 carton limit per transaction
- 9,999 pallet limit per transaction
- 5 login attempts per 15 minutes
- 100 record pagination limit

These were NOT changed in this PR - only the 1-year date restriction was removed.

## Testing
- Historical transactions can now be entered
- Future date validation still works
- Other validations remain unchanged