### PR TITLE
fix: Adjust validation limits to more practical values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "warehouse-management-system",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "scripts": {
     "dev": "node scripts/dev/dev-webpack.js",

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -183,7 +183,9 @@ export async function POST(request: NextRequest) {
       }, { status: 409 })
     }
 
-    // Check for backdated transactions - prevent inserting transactions before the last transaction
+    // Backdating check temporarily disabled - businesses need flexibility for corrections
+    // TODO: Re-enable with override capability for admins
+    /*
     const lastTransaction = await prisma.inventoryTransaction.findFirst({
       where: { warehouseId },
       orderBy: { transactionDate: 'desc' },
@@ -200,6 +202,7 @@ export async function POST(request: NextRequest) {
         }
       }, { status: 400 })
     }
+    */
 
     // Validate all items before processing
     for (const item of itemsArray) {
@@ -218,17 +221,17 @@ export async function POST(request: NextRequest) {
       }
       
       // Validate maximum cartons (prevent unrealistic values)
-      if (item.cartons > 99999) {
+      if (item.cartons > 10000) {
         return NextResponse.json({ 
-          error: `Cartons value too large for SKU ${item.skuCode}. Maximum allowed: 99,999` 
+          error: `Cartons value too large for SKU ${item.skuCode}. Maximum allowed: 10,000` 
         }, { status: 400 })
       }
       
       // Validate pallets if provided
       if (item.pallets !== undefined && item.pallets !== null) {
-        if (!Number.isInteger(item.pallets) || item.pallets < 0 || item.pallets > 9999) {
+        if (!Number.isInteger(item.pallets) || item.pallets < 0 || item.pallets > 5000) {
           return NextResponse.json({ 
-            error: `Pallets must be integers between 0 and 9,999. Invalid value for SKU ${item.skuCode}` 
+            error: `Pallets must be integers between 0 and 5,000. Invalid value for SKU ${item.skuCode}` 
           }, { status: 400 })
         }
       }

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -18,7 +18,7 @@ export const apiRateLimit = {
 
 export const uploadRateLimit = {
   windowMs: 5 * 60 * 1000, // 5 minutes
-  max: 10, // 10 uploads per 5 minutes
+  max: 20, // 20 uploads per 5 minutes
   message: 'Too many file uploads. Please wait before uploading more files.',
 }
 


### PR DESCRIPTION
## Summary
Adjusts various validation limits to more practical values for business operations.

## Changes
- **Carton limit:** Reduced from 99,999 to 10,000
- **Pallet limit:** Reduced from 9,999 to 5,000
- **File upload limit:** Increased from 10 to 20 per 5 minutes
- **Backdating prevention:** Temporarily disabled (commented out)

## Version
Updated to 0.3.1

## Rationale
- 10,000 cartons and 5,000 pallets are more realistic maximums
- 20 file uploads allows for bulk operations
- Backdating prevention was blocking legitimate corrections and adjustments