### PR TITLE
fix: resolve TypeScript errors blocking CI

### DIFF
--- a/src/app/operations/transactions/[id]/page.tsx
+++ b/src/app/operations/transactions/[id]/page.tsx
@@ -63,6 +63,8 @@ interface Attachment {
   s3Key?: string // S3 key for new uploads
   s3Url?: string // Presigned URL for viewing
   category: string
+  uploadedAt?: string
+  uploadedBy?: string
 }
 
 interface AuditLog {
@@ -284,7 +286,7 @@ export default function TransactionDetailPage() {
     }
     
     setAttachments(prev => ({ ...prev, [category]: previewAttachment }))
-    toast.info(`${getCategoryLabel(category)} selected. Will upload when you save.`)
+    toast(`${getCategoryLabel(category)} selected. Will upload when you save.`)
     
     // Clear any existing upload progress for this category
     setUploadProgress(prev => {
@@ -1086,7 +1088,7 @@ export default function TransactionDetailPage() {
               <div>
                 <span className="text-gray-600">Last updated:</span>
                 <span className="ml-2 font-medium">
-                  {new Date(auditLogs[0].createdAt).toLocaleString()} by {auditLogs[0].userName}
+                  {new Date(auditLogs[0].createdAt).toLocaleString()} by {auditLogs[0].changedBy.fullName}
                 </span>
               </div>
             )}


### PR DESCRIPTION
## Summary
- Fixed TypeScript compilation errors that were causing CI failures on main branch

## Changes
- Add `uploadedAt` and `uploadedBy` fields to Attachment interface
- Fix `toast.info()` to use regular `toast()` method (react-hot-toast doesn't have info method)
- Replace `auditLogs[0].userName` with correct `auditLogs[0].changedBy.fullName` reference

## Impact
These errors were preventing GitHub Actions from passing after the v0.3.2 release was merged.